### PR TITLE
LIBSEARCH-104. Updated searcher to Rails 5.2.2.1

### DIFF
--- a/quick_search-drum_searcher.gemspec
+++ b/quick_search-drum_searcher.gemspec
@@ -21,5 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri'
   s.add_dependency 'quick_search-core', '~> 0'
   s.add_development_dependency 'rubocop', '= 0.52.1'
-  s.add_development_dependency 'sqlite3'
+  # sqlite3 loaded for testing with the "dummy" application
+  # Limiting to v1.3.6 because v1.4 is incompatible with Rails 5.2
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end

--- a/test/dummy/config/secrets.yml
+++ b/test/dummy/config/secrets.yml
@@ -1,0 +1,32 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rails secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+# Shared secrets are available across all environments.
+
+# shared:
+#   api_key: a1B2c3D4e5F6
+
+# Environmental secrets are only available for that specific environment.
+
+development:
+  secret_key_base: 010f25c4593db71553b4ff9bf0a417954f506fa9e76cb6c5a6079a0d63790e47d6db6e5c7d876c36dd9ebcd1af5f99d5804a94a54d61f63b4f8d58fa489b43dc
+
+test:
+  secret_key_base: a425e466d392f4a4557ce3e9a559e82d4a504be5a953f71c0f64ddd1e1ebe4e8014183a6d6151ec6091f47e51903c180b8afb4a20ec071d2a75a07fe80598bec
+
+# Do not keep production secrets in the unencrypted secrets file.
+# Instead, either read values from the environment.
+# Or, use `bin/rails secrets:setup` to configure encrypted secrets
+# and move the `production:` environment over there.
+
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,8 @@
 ENV['RAILS_ENV'] = 'test'
 
 require_relative '../test/dummy/config/environment'
-#ActiveRecord::Migrator.migrations_paths = [File.expand_path('../test/dummy/db/migrate', __dir__)]
-#ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
+ActiveRecord::Migrator.migrations_paths = [File.expand_path('../test/dummy/db/migrate', __dir__)]
+ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
 require 'rails/test_help'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
@@ -13,9 +13,9 @@ require 'rails/test_help'
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 # Load fixtures from the engine
-#if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-#  ActiveSupport::TestCase.fixture_path = File.expand_path('fixtures', __dir__)
-#  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-#  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + '/files'
-#  ActiveSupport::TestCase.fixtures :all
-#end
+if ActiveSupport::TestCase.respond_to?(:fixture_path=)
+  ActiveSupport::TestCase.fixture_path = File.expand_path('fixtures', __dir__)
+  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
+  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + '/files'
+  ActiveSupport::TestCase.fixtures :all
+end


### PR DESCRIPTION
Fixes GitHub-identified vulnerabilities

Limited sqlite3 gem to v1.3.6 because of an Rails 5.2 incompatibility
with sqlite3 v1.4.

Added test/dummy/config/secrets.yml to enabled tests to run.

https://issues.umd.edu/browse/LIBSEARCH-104